### PR TITLE
Add basic React app designer skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# react-app-config-builder
+# React App Designer
+
+A simple React application for visually designing React apps. Drag elements onto the canvas and configure their properties. Configurations can be exported as YAML.
+
+## Development
+
+```bash
+npm install
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "react-app-designer",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "^5.0.1",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
+    "yaml": "^2.3.2"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>React App Designer</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import Canvas from './Canvas';
+import Sidebar from './Sidebar';
+import PropertyPanel from './PropertyPanel';
+import PageTabs from './PageTabs';
+import { defaultElementProps } from './components';
+
+let idCounter = 1;
+
+export default function App() {
+  const [pages, setPages] = useState([{ name: 'Page1', elements: [] }]);
+  const [activePage, setActivePage] = useState(0);
+  const [selectedId, setSelectedId] = useState(null);
+
+  const active = pages[activePage];
+
+  const handleDrop = (type, offset) => {
+    const newEl = {
+      id: `el_${idCounter++}`,
+      type,
+      ...defaultElementProps,
+      position: { x: offset.x, y: offset.y },
+    };
+    const newPages = [...pages];
+    newPages[activePage].elements.push(newEl);
+    setPages(newPages);
+  };
+
+  const handleSelect = id => setSelectedId(id);
+
+  const handleElementChange = updated => {
+    const newPages = pages.map((page, idx) => {
+      if (idx !== activePage) return page;
+      return {
+        ...page,
+        elements: page.elements.map(el => (el.id === updated.id ? updated : el)),
+      };
+    });
+    setPages(newPages);
+  };
+
+  const handleAddPage = () => {
+    setPages([...pages, { name: `Page${pages.length + 1}`, elements: [] }]);
+  };
+
+  const saveYaml = () => {
+    const yamlData = { pages };
+    const yaml = JSON.stringify(yamlData, null, 2); // placeholder for real YAML
+    console.log(yaml);
+  };
+
+  const selectedEl = active.elements.find(el => el.id === selectedId);
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+        <PageTabs pages={pages} active={activePage} onAdd={handleAddPage} onSelect={setActivePage} />
+        <div style={{ display: 'flex', flex: 1 }}>
+          <Canvas elements={active.elements} onDrop={handleDrop} onSelect={handleSelect} selectedId={selectedId} />
+          <div style={{ width: 250, display: 'flex', flexDirection: 'column', borderLeft: '1px solid #ccc' }}>
+            <Sidebar />
+            <div style={{ flex: 1, borderTop: '1px solid #ccc', overflowY: 'auto' }}>
+              <PropertyPanel element={selectedEl} onChange={handleElementChange} />
+            </div>
+          </div>
+        </div>
+        <div style={{ padding: 4, borderTop: '1px solid #ccc' }}>
+          <button onClick={saveYaml}>Save Config</button>
+        </div>
+      </div>
+    </DndProvider>
+  );
+}

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useDrop } from 'react-dnd';
+
+export default function Canvas({ elements, onDrop, onSelect, selectedId }) {
+  const [, drop] = useDrop({
+    accept: 'component',
+    drop: (item, monitor) => {
+      const offset = monitor.getClientOffset();
+      onDrop(item.type, offset);
+    },
+  });
+
+  return (
+    <div ref={drop} style={{ flex: 1, position: 'relative', border: '1px solid #ccc' }}>
+      {elements.map(el => (
+        <div
+          key={el.id}
+          onClick={() => onSelect(el.id)}
+          style={{
+            position: 'absolute',
+            left: el.position.x,
+            top: el.position.y,
+            width: el.size.width,
+            height: el.size.height,
+            border: el.id === selectedId ? '2px solid blue' : '1px solid #999',
+            padding: 4,
+            boxSizing: 'border-box',
+            background: '#fff',
+          }}
+        >
+          {el.type}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/PageTabs.js
+++ b/src/PageTabs.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function PageTabs({ pages, active, onAdd, onSelect }) {
+  return (
+    <div style={{ display: 'flex', borderBottom: '1px solid #ccc' }}>
+      {pages.map((page, idx) => (
+        <div
+          key={page.name}
+          onClick={() => onSelect(idx)}
+          style={{
+            padding: '4px 8px',
+            cursor: 'pointer',
+            background: idx === active ? '#eee' : '#f9f9f9',
+            borderRight: '1px solid #ccc',
+          }}
+        >
+          {page.name}
+        </div>
+      ))}
+      <div onClick={onAdd} style={{ padding: '4px 8px', cursor: 'pointer' }}>+</div>
+    </div>
+  );
+}

--- a/src/PropertyPanel.js
+++ b/src/PropertyPanel.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export default function PropertyPanel({ element, onChange }) {
+  if (!element) {
+    return <div style={{ padding: 8 }}>Select an element</div>;
+  }
+
+  const update = (field, value) => {
+    onChange({ ...element, [field]: value });
+  };
+
+  return (
+    <div style={{ padding: 8 }}>
+      <div>ID: {element.id}</div>
+      <div style={{ marginTop: 8 }}>
+        <label>
+          X:
+          <input
+            type="number"
+            value={element.position.x}
+            onChange={e => update('position', { ...element.position, x: +e.target.value })}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Y:
+          <input
+            type="number"
+            value={element.position.y}
+            onChange={e => update('position', { ...element.position, y: +e.target.value })}
+          />
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/Sidebar.js
+++ b/src/Sidebar.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { useDrag } from 'react-dnd';
+import { componentLibrary } from './components';
+
+function DraggableItem({ type, label }) {
+  const [, drag] = useDrag({ type: 'component', item: { type } });
+  return (
+    <div ref={drag} style={{ padding: '4px 8px', border: '1px solid #ddd', marginBottom: 4, cursor: 'grab' }}>
+      {label}
+    </div>
+  );
+}
+
+export default function Sidebar() {
+  const [open, setOpen] = useState({ ui: true, charts: true, data: true });
+
+  return (
+    <div style={{ width: 250, borderLeft: '1px solid #ccc', padding: 8, overflowY: 'auto' }}>
+      {Object.entries(componentLibrary).map(([key, items]) => (
+        <div key={key} style={{ marginBottom: 8 }}>
+          <div
+            style={{ fontWeight: 'bold', cursor: 'pointer' }}
+            onClick={() => setOpen({ ...open, [key]: !open[key] })}
+          >
+            {key.toUpperCase()}
+          </div>
+          {open[key] && (
+            <div>
+              {items.map(item => (
+                <DraggableItem key={item.type} type={item.type} label={item.label} />
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components.js
+++ b/src/components.js
@@ -1,0 +1,30 @@
+export const componentLibrary = {
+  ui: [
+    { type: 'container', label: 'Container' },
+    { type: 'tabs', label: 'Tabs' },
+    { type: 'textbox', label: 'Text Box' },
+    { type: 'modal', label: 'Modal Dialog' },
+    { type: 'button', label: 'Button' },
+    { type: 'image', label: 'Image Placeholder' },
+  ],
+  charts: [
+    { type: 'bar_chart', label: 'Bar Chart' },
+    { type: 'pie_chart', label: 'Pie Chart' },
+    { type: 'ag_grid', label: 'AG Grid' },
+    { type: 'text_display', label: 'Text Display' },
+    { type: 'table', label: 'Simple Table' },
+    { type: 'slicer', label: 'Slicer' },
+    { type: 'tree_chart', label: 'Tree Chart' },
+  ],
+  data: [
+    { type: 'editable_grid', label: 'Editable Grid' },
+    { type: 'form_inputs', label: 'Form Inputs' },
+    { type: 'file_upload', label: 'File Upload' },
+  ],
+};
+
+export const defaultElementProps = {
+  position: { x: 0, y: 0 },
+  size: { width: 200, height: 150 },
+  properties: {},
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,8 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+#root {
+  height: 100vh;
+  display: flex;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- add initial React project with designer UI skeleton
- implement drag-and-drop canvas and sidebar
- basic property panel and page tabs
- initial package configuration and README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6885368736cc83209aeb4d5c63d7bc93